### PR TITLE
Improve readme : add mineflayer and youtube links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Mineflayer-Youtube-Tutorials
-A collection of source files for my Mineflayer Youtube tutorial videos.
+
+A collection of source files for my [Mineflayer Youtube tutorial videos](https://www.youtube.com/playlist?list=PLh_alXmxHmzGy3FKbo95AkPp5D8849PEV).
+
+[mineflayer](https://github.com/PrismarineJS/mineflayer) is the lib on top of which these examples are built
+
+[<img src="https://img.youtube.com/vi/ltWosy4Z0Kw/0.jpg" alt="tutorial 1" width="200">](https://www.youtube.com/watch?v=ltWosy4Z0Kw)
+[<img src="https://img.youtube.com/vi/UWGSf08wQSc/0.jpg" alt="tutorial 2" width="200">](https://www.youtube.com/watch?v=UWGSf08wQSc)
+[<img src="https://img.youtube.com/vi/ssWE0kXDGJE/0.jpg" alt="tutorial 3" width="200">](https://www.youtube.com/watch?v=ssWE0kXDGJE)
+[<img src="https://img.youtube.com/vi/walbRk20KYU/0.jpg" alt="tutorial 4" width="200">](https://www.youtube.com/watch?v=walbRk20KYU)


### PR DESCRIPTION
Also I think it would be nice to add a link to https://github.com/PrismarineJS/mineflayer in the youtube video description (this one for example https://www.youtube.com/watch?v=ltWosy4Z0Kw&list=PLh_alXmxHmzGy3FKbo95AkPp5D8849PEV&index=1), in case people find these videos but don't know about mineflayer.
What do you think @TheDudeFromCI ?